### PR TITLE
Feature/timing adjust

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(loci-firmware PRIVATE
     mia/mon/rom.c
     mia/mon/set.c
     mia/mon/vip.c
+    mia/sys/adj.c
     mia/sys/cfg.c
     mia/sys/com.c
     mia/sys/cpu.c

--- a/src/mia/main.c
+++ b/src/mia/main.c
@@ -18,6 +18,7 @@
 #include "mon/mon.h"
 #include "mon/ram.h"
 #include "mon/rom.h"
+#include "sys/adj.h"
 #include "sys/com.h"
 #include "sys/cfg.h"
 #include "sys/cpu.h"
@@ -69,6 +70,7 @@ static void init(void)
 
     // Misc kernel modules, add yours here
     oem_init();
+    adj_init();
 
     //aud_init();
     kbd_init();

--- a/src/mia/mon/mon.c
+++ b/src/mia/mon/mon.c
@@ -48,11 +48,6 @@ static struct
     {6, "upload", fil_mon_upload},
     {6, "unlink", fil_mon_unlink},
     {6, "binary", ram_mon_binary},
-    {4, "tmap", adj_mon_map},
-    {4, "tior", adj_mon_act_read},
-    {4, "tiow", adj_mon_act_write},
-    {4, "tiod", adj_mon_io_read},
-    {5, "taddr", adj_mon_read_addr},
 };
 static const size_t COMMANDS_COUNT = sizeof COMMANDS / sizeof *COMMANDS;
 

--- a/src/mia/mon/mon.c
+++ b/src/mia/mon/mon.c
@@ -13,6 +13,7 @@
 #include "mon/ram.h"
 #include "mon/rom.h"
 #include "mon/set.h"
+#include "sys/adj.h"
 #include "sys/com.h"
 #include "sys/mem.h"
 #include "sys/sys.h"
@@ -47,6 +48,11 @@ static struct
     {6, "upload", fil_mon_upload},
     {6, "unlink", fil_mon_unlink},
     {6, "binary", ram_mon_binary},
+    {4, "tmap", adj_mon_map},
+    {4, "tior", adj_mon_act_read},
+    {4, "tiow", adj_mon_act_write},
+    {4, "tiod", adj_mon_io_read},
+    {5, "taddr", adj_mon_read_addr},
 };
 static const size_t COMMANDS_COUNT = sizeof COMMANDS / sizeof *COMMANDS;
 

--- a/src/mia/mon/set.c
+++ b/src/mia/mon/set.c
@@ -186,6 +186,111 @@ static void set_vga(const char *args, size_t len)
     set_print_vga();
 }
 
+static void set_print_map_delay(void)
+{
+    printf("TMAP: %d\n", cfg_get_map_delay());
+}
+
+static void set_map_delay(const char *args, size_t len)
+{
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        cfg_set_map_delay(delay);
+    }
+    set_print_map_delay();
+}
+
+static void set_print_io_write_delay(void)
+{
+    printf("TIOW: %d\n", cfg_get_io_write_delay());
+}
+
+static void set_io_write_delay(const char *args, size_t len)
+{
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        cfg_set_io_write_delay(delay);
+    }
+    set_print_io_write_delay();    
+}
+
+static void set_print_io_read_delay(void)
+{
+    printf("TIOR: %d\n", cfg_get_io_read_delay());
+}
+
+static void set_io_read_delay(const char *args, size_t len)
+{
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        cfg_set_io_read_delay(delay);
+    }
+    set_print_io_read_delay();    
+}
+
+static void set_print_io_data_delay(void)
+{
+    printf("TIOD: %d\n", cfg_get_io_data_delay());
+}
+
+static void set_io_data_delay(const char *args, size_t len)
+{
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        cfg_set_io_data_delay(delay);
+    }
+    set_print_io_data_delay();
+}
+
+static void set_print_read_addr_delay(void)
+{
+    printf("TADR: %d\n", cfg_get_read_addr_delay());
+}
+
+static void set_read_addr_delay(const char *args, size_t len)
+{
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        cfg_set_read_addr_delay(delay);
+    }
+    set_print_read_addr_delay();
+}
+
 typedef void (*set_function)(const char *, size_t);
 static struct
 {
@@ -199,6 +304,10 @@ static struct
     {4, "boot", set_boot},
     {2, "cp", set_code_page},
     {3, "vga", set_vga},
+    {4, "tmap", set_map_delay},
+    {4, "tiow", set_io_read_delay},
+    {4, "tior", set_io_write_delay},
+    {4, "tadr", set_read_addr_delay},
 };
 static const size_t SETTERS_COUNT = sizeof SETTERS / sizeof *SETTERS;
 
@@ -210,6 +319,11 @@ static void set_print_all(void)
     set_print_boot();
     set_print_code_page();
     set_print_vga();
+    set_print_map_delay();
+    set_print_io_write_delay();
+    set_print_io_read_delay();
+    set_print_io_data_delay();
+    set_print_read_addr_delay();
 }
 
 void set_mon_set(const char *args, size_t len)

--- a/src/mia/mon/set.c
+++ b/src/mia/mon/set.c
@@ -305,8 +305,9 @@ static struct
     {2, "cp", set_code_page},
     {3, "vga", set_vga},
     {4, "tmap", set_map_delay},
-    {4, "tiow", set_io_read_delay},
-    {4, "tior", set_io_write_delay},
+    {4, "tior", set_io_read_delay},
+    {4, "tiow", set_io_write_delay},
+    {4, "tiod", set_io_data_delay},
     {4, "tadr", set_read_addr_delay},
 };
 static const size_t SETTERS_COUNT = sizeof SETTERS / sizeof *SETTERS;

--- a/src/mia/oric/map.c
+++ b/src/mia/oric/map.c
@@ -6,6 +6,7 @@
 
 #include "main.h"
 #include "oric/map.h"
+#include "sys/cfg.h"
 #include "sys/ext.h"
 #include "sys/mem.h"
 #include "sys/ssd.h"
@@ -16,10 +17,6 @@
 #include "hardware/structs/bus_ctrl.h"
 #include "littlefs/lfs_util.h"
 #include "mia.pio.h"
-
-//MUST be updated if PIO is changed
-#define MAP_TUNE_INSTR 5
-//TODO: Add assert that we're modding the right instruction
 
 void map_init(void)
 {
@@ -52,9 +49,10 @@ void map_trigger_irq(void)
 
 void map_api_tune(void)
 {
-    uint8_t delay = API_A & 0x1F;   //Range 0-31
-    printf("MAP tune %d\n",delay);
-    MIA_MAP_PIO->instr_mem[MAP_TUNE_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    uint8_t delay = API_A;          //Range 0-31 for setting, other return current
     api_sync_xstack();              //For safety only
-    return api_return_ax(delay);
+    if(cfg_set_map_delay(delay)){
+        printf("MAP tune %d\n",delay);
+    }        
+    return api_return_ax(cfg_get_map_delay());
 }

--- a/src/mia/oric/map.c
+++ b/src/mia/oric/map.c
@@ -51,8 +51,6 @@ void map_api_tune(void)
 {
     uint8_t delay = API_A;          //Range 0-31 for setting, other return current
     api_sync_xstack();              //For safety only
-    if(cfg_set_map_delay(delay)){
-        printf("MAP tune %d\n",delay);
-    }        
+    cfg_set_map_delay(delay);        
     return api_return_ax(cfg_get_map_delay());
 }

--- a/src/mia/sys/adj.c
+++ b/src/mia/sys/adj.c
@@ -1,0 +1,120 @@
+#include "main.h"
+#include "str.h"
+#include "pico/stdlib.h"
+#include "mia.pio.h"
+
+//MUST be updated if PIO is changed
+#define ADJ_MAP_INSTR  (5)
+#define ADJ_ACTR_INSTR (mia_map_program.length + 2)
+#define ADJ_ACTW_INSTR (mia_map_program.length + 10)
+#define ADJ_ADDR_INSTR (mia_read_data_program.length + 0)
+#define ADJ_IO_INSTR   (mia_read_data_program.length + mia_read_addr_program.length + 3)
+
+
+uint8_t adj_map_delay(uint8_t delay)
+{
+    delay &= 0x1f;
+    printf("MAP tune %d\n",delay);
+    MIA_MAP_PIO->instr_mem[ADJ_MAP_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    return delay;
+}
+
+uint8_t adj_actr_delay(uint8_t delay)
+{
+    delay &= 0x1f;
+    printf("ACT read tune %d\n",delay);
+    MIA_ACT_PIO->instr_mem[ADJ_ACTR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    return delay;
+}
+
+uint8_t adj_actw_delay(uint8_t delay)
+{
+    delay &= 0x1f;
+    printf("ACT write tune %d\n",delay);
+    MIA_ACT_PIO->instr_mem[ADJ_ACTW_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    return delay;
+}
+
+uint8_t adj_addr_delay(uint8_t delay)
+{
+    delay &= 0x1f;
+    printf("Addr tune %d\n",delay);
+    MIA_READ_PIO->instr_mem[ADJ_ADDR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    return delay;
+}
+
+uint8_t adj_io_read_delay(uint8_t delay)
+{
+    delay &= 0x07;
+    printf("IO read tune %d\n",delay);
+    MIA_READ_PIO->instr_mem[ADJ_IO_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    return delay;
+}
+
+//Monitor command functions for tmap tior tiow tiod taddr
+
+void adj_mon_map(const char *args, size_t len){
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        adj_map_delay(delay);
+    }
+}
+void adj_mon_act_read(const char *args, size_t len){
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        adj_actr_delay(delay);
+    }
+}
+void adj_mon_act_write(const char *args, size_t len){
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        adj_actw_delay(delay);
+    }
+}
+void adj_mon_io_read(const char *args, size_t len){
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        adj_io_read_delay(delay);
+    }
+}
+void adj_mon_read_addr(const char *args, size_t len){
+    uint32_t delay;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &delay) ||
+            !parse_end(args, len))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+        adj_addr_delay(delay);
+    }
+}

--- a/src/mia/sys/adj.c
+++ b/src/mia/sys/adj.c
@@ -1,6 +1,7 @@
 #include "main.h"
 #include "str.h"
 #include <stdio.h>
+#include "sys/cfg.h"
 #include "pico/stdlib.h"
 #include "mia.pio.h"
 
@@ -50,4 +51,13 @@ uint8_t adj_io_data_delay(uint8_t delay)
     printf("IO data tune %d\n",delay);
     MIA_READ_PIO->instr_mem[ADJ_IO_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
+}
+
+void adj_init(void){
+    //Set delays from cfg
+    adj_map_delay(cfg_get_map_delay());
+    adj_io_write_delay(cfg_get_io_write_delay());
+    adj_io_read_delay(cfg_get_io_read_delay());
+    adj_io_data_delay(cfg_get_io_data_delay());
+    adj_read_addr_delay(cfg_get_read_addr_delay());
 }

--- a/src/mia/sys/adj.c
+++ b/src/mia/sys/adj.c
@@ -2,22 +2,23 @@
 #include "str.h"
 #include <stdio.h>
 #include "sys/cfg.h"
+#include "sys/mia.h"
 #include "pico/stdlib.h"
 #include "mia.pio.h"
 
 //MUST be updated if PIO is changed
 #define ADJ_MAP_INSTR  (5)
-#define ADJ_ACTR_INSTR (mia_map_program.length + 2)
-#define ADJ_ACTW_INSTR (mia_map_program.length + 10)
-#define ADJ_ADDR_INSTR (mia_read_data_program.length + 0)
-#define ADJ_IO_INSTR   (mia_read_data_program.length + mia_read_addr_program.length + 3)
+#define ADJ_ACTR_INSTR (2)
+#define ADJ_ACTW_INSTR (11)
+#define ADJ_ADDR_INSTR (0)
+#define ADJ_IO_INSTR   (3)
 
 
 uint8_t adj_map_delay(uint8_t delay)
 {
     delay &= 0x1f;
     printf("MAP tune %d\n",delay);
-    MIA_MAP_PIO->instr_mem[ADJ_MAP_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    MIA_MAP_PIO->instr_mem[mia_get_map_prg_offset() + ADJ_MAP_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
@@ -25,7 +26,7 @@ uint8_t adj_io_read_delay(uint8_t delay)
 {
     delay &= 0x1f;
     printf("IO read tune %d\n",delay);
-    MIA_ACT_PIO->instr_mem[ADJ_ACTR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    MIA_ACT_PIO->instr_mem[mia_get_act_prg_offset() + ADJ_ACTR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
@@ -33,7 +34,7 @@ uint8_t adj_io_write_delay(uint8_t delay)
 {
     delay &= 0x1f;
     printf("IO write tune %d\n",delay);
-    MIA_ACT_PIO->instr_mem[ADJ_ACTW_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    MIA_ACT_PIO->instr_mem[mia_get_act_prg_offset() + ADJ_ACTW_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
@@ -41,7 +42,7 @@ uint8_t adj_read_addr_delay(uint8_t delay)
 {
     delay &= 0x07;
     printf("Addr tune %d\n",delay);
-    MIA_READ_PIO->instr_mem[ADJ_ADDR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    MIA_READ_PIO->instr_mem[mia_get_read_addr_prg_offset() + ADJ_ADDR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
@@ -49,7 +50,7 @@ uint8_t adj_io_data_delay(uint8_t delay)
 {
     delay &= 0x07;
     printf("IO data tune %d\n",delay);
-    MIA_READ_PIO->instr_mem[ADJ_IO_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
+    MIA_IO_READ_PIO->instr_mem[mia_get_io_read_prg_offset() + ADJ_IO_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 

--- a/src/mia/sys/adj.c
+++ b/src/mia/sys/adj.c
@@ -1,5 +1,6 @@
 #include "main.h"
 #include "str.h"
+#include <stdio.h>
 #include "pico/stdlib.h"
 #include "mia.pio.h"
 
@@ -19,102 +20,34 @@ uint8_t adj_map_delay(uint8_t delay)
     return delay;
 }
 
-uint8_t adj_actr_delay(uint8_t delay)
+uint8_t adj_io_read_delay(uint8_t delay)
 {
     delay &= 0x1f;
-    printf("ACT read tune %d\n",delay);
+    printf("IO read tune %d\n",delay);
     MIA_ACT_PIO->instr_mem[ADJ_ACTR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
-uint8_t adj_actw_delay(uint8_t delay)
+uint8_t adj_io_write_delay(uint8_t delay)
 {
     delay &= 0x1f;
-    printf("ACT write tune %d\n",delay);
+    printf("IO write tune %d\n",delay);
     MIA_ACT_PIO->instr_mem[ADJ_ACTW_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
-uint8_t adj_addr_delay(uint8_t delay)
+uint8_t adj_read_addr_delay(uint8_t delay)
 {
-    delay &= 0x1f;
+    delay &= 0x07;
     printf("Addr tune %d\n",delay);
     MIA_READ_PIO->instr_mem[ADJ_ADDR_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
 }
 
-uint8_t adj_io_read_delay(uint8_t delay)
+uint8_t adj_io_data_delay(uint8_t delay)
 {
     delay &= 0x07;
-    printf("IO read tune %d\n",delay);
+    printf("IO data tune %d\n",delay);
     MIA_READ_PIO->instr_mem[ADJ_IO_INSTR] = (uint16_t)(pio_encode_nop() | pio_encode_delay(delay));
     return delay;
-}
-
-//Monitor command functions for tmap tior tiow tiod taddr
-
-void adj_mon_map(const char *args, size_t len){
-    uint32_t delay;
-    if (len)
-    {
-        if (!parse_uint32(&args, &len, &delay) ||
-            !parse_end(args, len))
-        {
-            printf("?invalid argument\n");
-            return;
-        }
-        adj_map_delay(delay);
-    }
-}
-void adj_mon_act_read(const char *args, size_t len){
-    uint32_t delay;
-    if (len)
-    {
-        if (!parse_uint32(&args, &len, &delay) ||
-            !parse_end(args, len))
-        {
-            printf("?invalid argument\n");
-            return;
-        }
-        adj_actr_delay(delay);
-    }
-}
-void adj_mon_act_write(const char *args, size_t len){
-    uint32_t delay;
-    if (len)
-    {
-        if (!parse_uint32(&args, &len, &delay) ||
-            !parse_end(args, len))
-        {
-            printf("?invalid argument\n");
-            return;
-        }
-        adj_actw_delay(delay);
-    }
-}
-void adj_mon_io_read(const char *args, size_t len){
-    uint32_t delay;
-    if (len)
-    {
-        if (!parse_uint32(&args, &len, &delay) ||
-            !parse_end(args, len))
-        {
-            printf("?invalid argument\n");
-            return;
-        }
-        adj_io_read_delay(delay);
-    }
-}
-void adj_mon_read_addr(const char *args, size_t len){
-    uint32_t delay;
-    if (len)
-    {
-        if (!parse_uint32(&args, &len, &delay) ||
-            !parse_end(args, len))
-        {
-            printf("?invalid argument\n");
-            return;
-        }
-        adj_addr_delay(delay);
-    }
 }

--- a/src/mia/sys/adj.h
+++ b/src/mia/sys/adj.h
@@ -2,13 +2,7 @@
 #include "pico/stdlib.h"
 
 uint8_t adj_map_delay(uint8_t delay);
-uint8_t adj_actr_delay(uint8_t delay);
-uint8_t adj_actw_delay(uint8_t delay);
-uint8_t adj_addr_delay(uint8_t delay);
 uint8_t adj_io_read_delay(uint8_t delay);
-
-void adj_mon_map(const char *args, size_t len);
-void adj_mon_act_read(const char *args, size_t len);
-void adj_mon_act_write(const char *args, size_t len);
-void adj_mon_io_read(const char *args, size_t len);
-void adj_mon_read_addr(const char *args, size_t len);
+uint8_t adj_io_write_delay(uint8_t delay);
+uint8_t adj_io_data_delay(uint8_t delay);
+uint8_t adj_read_addr_delay(uint8_t delay);

--- a/src/mia/sys/adj.h
+++ b/src/mia/sys/adj.h
@@ -6,3 +6,5 @@ uint8_t adj_io_read_delay(uint8_t delay);
 uint8_t adj_io_write_delay(uint8_t delay);
 uint8_t adj_io_data_delay(uint8_t delay);
 uint8_t adj_read_addr_delay(uint8_t delay);
+
+void adj_init(void);

--- a/src/mia/sys/adj.h
+++ b/src/mia/sys/adj.h
@@ -1,0 +1,14 @@
+#include "main.h"
+#include "pico/stdlib.h"
+
+uint8_t adj_map_delay(uint8_t delay);
+uint8_t adj_actr_delay(uint8_t delay);
+uint8_t adj_actw_delay(uint8_t delay);
+uint8_t adj_addr_delay(uint8_t delay);
+uint8_t adj_io_read_delay(uint8_t delay);
+
+void adj_mon_map(const char *args, size_t len);
+void adj_mon_act_read(const char *args, size_t len);
+void adj_mon_act_write(const char *args, size_t len);
+void adj_mon_io_read(const char *args, size_t len);
+void adj_mon_read_addr(const char *args, size_t len);

--- a/src/mia/sys/cfg.c
+++ b/src/mia/sys/cfg.c
@@ -305,7 +305,7 @@ bool cfg_set_io_write_delay(uint8_t delay)
     bool ok = false;
     if(delay <= 31){
         cfg_io_write_delay = delay;
-        adj_io_write_delay(cfg_io_read_delay);
+        adj_io_write_delay(cfg_io_write_delay);
         ok = true;
         cfg_save_with_boot_opt(NULL);
     }

--- a/src/mia/sys/cfg.c
+++ b/src/mia/sys/cfg.c
@@ -19,9 +19,14 @@
 // +R0         | RESB
 // +S437       | Code Page
 // +D0         | VGA display type
+// +TM10       | MAP signal timing 0-31
+// +TR0        | IO Read signal timing 0-31
+// +TW0        | IO Write signal timing 0-31
+// +TD0        | IO Data signal timing 0-7
+// +TA0        | ROM Read address signal timing 0-7
 // BASIC       | Boot ROM - Must be last
 
-#define CFG_VERSION 1
+#define CFG_VERSION 2
 static const char filename[] = "CONFIG.SYS";
 
 static uint32_t cfg_phi2_khz;
@@ -29,6 +34,11 @@ static uint8_t cfg_reset_ms;
 static uint8_t cfg_caps;
 static uint32_t cfg_codepage;
 static uint8_t cfg_vga_display;
+static uint8_t cfg_map_delay;
+static uint8_t cfg_io_read_delay;
+static uint8_t cfg_io_write_delay;
+static uint8_t cfg_io_data_delay;
+static uint8_t cfg_read_addr_delay;
 
 // Optional string can replace boot string
 static void cfg_save_with_boot_opt(char *opt_str)
@@ -67,6 +77,11 @@ static void cfg_save_with_boot_opt(char *opt_str)
                                "+C%d\n"
                                "+S%d\n"
                                "+D%d\n"
+                               "+TM%d\n"
+                               "+TR%d\n"
+                               "+TW%d\n"
+                               "+TD%d\n"
+                               "+TA%d\n"
                                "%s",
                                CFG_VERSION,
                                cfg_phi2_khz,
@@ -74,6 +89,11 @@ static void cfg_save_with_boot_opt(char *opt_str)
                                cfg_caps,
                                cfg_codepage,
                                cfg_vga_display,
+                               cfg_map_delay,
+                               cfg_io_read_delay,
+                               cfg_io_write_delay,
+                               cfg_io_data_delay,
+                               cfg_read_addr_delay,
                                opt_str);
         if (lfsresult < 0)
             printf("?Unable to write %s contents (%d)\n", filename, lfsresult);
@@ -130,6 +150,30 @@ static void cfg_load_with_boot_opt(bool boot_only)
             default:
                 break;
             }
+        str = (char *)mbuf + 3;
+        len -= 1;
+        if (!boot_only && mbuf[1]=='T' && parse_uint32(&str, &len, &val)){
+            switch (mbuf[2])
+            {
+            case 'M':
+                cfg_map_delay = val;
+                break;
+            case 'W':
+                cfg_io_write_delay = val;
+                break;
+            case 'R':
+                cfg_io_read_delay = val;
+                break;
+            case 'D':
+                cfg_io_data_delay = val;
+                break;
+            case 'A':
+                cfg_read_addr_delay = val;
+                break;
+            default:
+                break;
+            }
+        }
     }
     lfsresult = lfs_file_close(&lfs_volume, &lfs_file);
     if (lfsresult < 0)
@@ -237,4 +281,89 @@ bool cfg_set_vga(uint8_t disp)
 uint8_t cfg_get_vga(void)
 {
     return cfg_vga_display;
+}
+
+bool cfg_set_map_delay(uint8_t delay)
+{
+    bool ok = false;
+    if(delay <= 31){
+        cfg_map_delay = delay;
+        adj_map_delay(cfg_map_delay);
+        ok = true;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return ok;
+}
+
+uint8_t cfg_get_map_delay(void)
+{
+    return cfg_map_delay;
+}
+
+bool cfg_set_io_write_delay(uint8_t delay)
+{
+    bool ok = false;
+    if(delay <= 31){
+        cfg_io_write_delay = delay;
+        adj_io_write_delay(cfg_io_read_delay);
+        ok = true;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return ok;
+}
+
+uint8_t cfg_get_io_write_delay(void)
+{
+    return cfg_io_write_delay;
+}
+
+bool cfg_set_io_read_delay(uint8_t delay)
+{
+    bool ok = false;
+    if(delay <= 31){
+        cfg_io_read_delay = delay;
+        adj_io_read_delay(cfg_io_read_delay);
+        ok = true;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return ok;
+}
+
+uint8_t cfg_get_io_read_delay(void)
+{
+    return cfg_io_read_delay;
+}
+
+bool cfg_set_io_data_delay(uint8_t delay)
+{
+    bool ok = false;
+    if(delay <= 7){
+        cfg_io_data_delay = delay;
+        adj_io_data_delay(cfg_io_data_delay);
+        ok = true;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return ok;
+}
+
+uint8_t cfg_get_io_data_delay(void)
+{
+    return cfg_io_data_delay;
+}
+
+bool cfg_set_read_addr_delay(uint8_t delay)
+{
+    bool ok = false;
+    if(delay <= 7){
+        cfg_read_addr_delay = delay;
+        adj_read_addr_delay(cfg_read_addr_delay);
+        ok = true;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return ok;
+}
+
+uint8_t cfg_get_read_addr_delay(void)
+{
+    return cfg_read_addr_delay;
 }

--- a/src/mia/sys/cfg.h
+++ b/src/mia/sys/cfg.h
@@ -30,5 +30,15 @@ bool cfg_set_codepage(uint32_t cp);
 uint16_t cfg_get_codepage(void);
 bool cfg_set_vga(uint8_t disp);
 uint8_t cfg_get_vga(void);
+bool cfg_set_map_delay(uint8_t delay);
+uint8_t cfg_get_map_delay(void);
+bool cfg_set_io_write_delay(uint8_t delay);
+uint8_t cfg_get_io_write_delay(void);
+bool cfg_set_io_read_delay(uint8_t delay);
+uint8_t cfg_get_io_read_delay(void);
+bool cfg_set_io_data_delay(uint8_t delay);
+uint8_t cfg_get_io_data_delay(void);
+bool cfg_set_read_addr_delay(uint8_t delay);
+uint8_t cfg_get_read_addr_delay(void);
 
 #endif /* _CFG_H_ */

--- a/src/mia/sys/mia.c
+++ b/src/mia/sys/mia.c
@@ -1119,12 +1119,15 @@ void mia_init(void)
     mia_boot_settings = 0;
 
     // the inits
+    // Same PIO order matters for timing tuning
     mia_map_pio_init(); //Must be first for MAP tuning
-    mia_read_pio_init();
+    mia_act_pio_init();
     //mia_write_pio_init();
+    
+    //Same PIO order matters timing tuning
+    mia_read_pio_init();    //read_data, read_addr
     mia_io_read_pio_init();
     mia_rom_read_pio_init();
-    mia_act_pio_init();
 }
 
 void mia_reclock(uint16_t clkdiv_int, uint8_t clkdiv_frac)

--- a/src/mia/sys/mia.c
+++ b/src/mia/sys/mia.c
@@ -829,11 +829,17 @@ static void mia_read_pio_init(void)
         true);
 }
 */
+static uint mia_read_addr_prg_offset;
+uint mia_get_read_addr_prg_offset(void){
+    return mia_read_addr_prg_offset;
+}
+
 static void mia_read_pio_init(void)
 { 
     // PIO for 6502 reads
     uint offset_d = pio_add_program(MIA_READ_PIO, &mia_read_data_program);
     uint offset_a = pio_add_program(MIA_READ_PIO, &mia_read_addr_program);
+    mia_read_addr_prg_offset = offset_a;
     pio_sm_config config_d = mia_read_data_program_get_default_config(offset_d);
     pio_sm_config config_a = mia_read_addr_program_get_default_config(offset_a);
     sm_config_set_out_pins(&config_d, D_PIN_BASE, 8);
@@ -903,10 +909,15 @@ static void mia_read_pio_init(void)
         true);
 }
 
+static uint mia_act_prg_offset;
+uint mia_get_act_prg_offset(void){
+    return mia_act_prg_offset;
+}
 static void mia_act_pio_init(void)
 {
     // PIO to supply action loop with events
     uint offset = pio_add_program(MIA_ACT_PIO, &mia_action_program);
+    mia_act_prg_offset = offset;
     pio_sm_config config = mia_action_program_get_default_config(offset);
     sm_config_set_in_pins(&config, A_PIN_BASE);
     sm_config_set_in_shift(&config, false, true, 25);
@@ -918,11 +929,17 @@ static void mia_act_pio_init(void)
     pio_sm_set_enabled(MIA_ACT_PIO, MIA_ACT_SM, true);
     multicore_launch_core1(act_loop);
 }
+
+static uint mia_io_read_prg_offset;
+uint mia_get_io_read_prg_offset(void){
+    return mia_io_read_prg_offset;
+}
 static void mia_io_read_pio_init(void)
 {
     
     // PIO to manage 6502 reads to Oric IO page 0x0300
     uint offset = pio_add_program(MIA_IO_READ_PIO, &mia_io_read_program);
+    mia_io_read_prg_offset = offset;
     pio_sm_config config = mia_io_read_program_get_default_config(offset);
     sm_config_set_in_pins(&config, A2_PIN);
     sm_config_set_in_shift(&config, false, true, 6);
@@ -1008,11 +1025,17 @@ static void mia_rom_read_pio_init(void)
 
 }
 
+static uint mia_map_prg_offset;
+uint mia_get_map_prg_offset(void){
+    return mia_map_prg_offset;
+}
+
 static void mia_map_pio_init(void)
 {
     
     // PIO to manage MAP signal timing
     uint offset = pio_add_program(MIA_MAP_PIO, &mia_map_program);
+    mia_map_prg_offset = offset;
     pio_sm_config config = mia_map_program_get_default_config(offset);
     sm_config_set_in_pins(&config, A13_PIN);
     sm_config_set_in_shift(&config, false, false, 0);

--- a/src/mia/sys/mia.h
+++ b/src/mia/sys/mia.h
@@ -55,4 +55,9 @@ void mia_set_rom_ram_enable(bool device_rom, bool overlay_ram);
 //Call boot from Oric - typical from CUmini ROM
 void mia_api_boot(void);
 
+unsigned int mia_get_act_prg_offset(void);
+unsigned int mia_get_io_read_prg_offset(void);
+unsigned int mia_get_read_addr_prg_offset(void);
+unsigned int mia_get_map_prg_offset(void);
+
 #endif /* _MIA_H_ */

--- a/src/mia/sys/mia.pio
+++ b/src/mia/sys/mia.pio
@@ -13,7 +13,7 @@
 start:
     wait 1 gpio 25  [15]
 .wrap_target
-    wait 0 gpio 25  [29] ;wait for phi2 negative edge + setup
+    wait 0 gpio 25  [29] ;wait for phi2 negative edge + setup <- act read timing adjust 0-31
     mov osr pins
     out null 8           ;Spool out A[7:0]
     out x 8              ;Get page address A[15:8]
@@ -22,7 +22,7 @@ start:
     in pins 25           ;Get RnW,D[7:0]:A[15:0] (autopush)
     jmp start            ;
 iswrite:                 ;Writes needs data to be stable (phi2 high)
-    wait 1 gpio 25  [20] ;Delay needed for stable data sampling
+    wait 1 gpio 25  [20] ;Delay needed for stable data sampling <- act write timing adjust 0-31
     in pins 25           ;Get RnW,D[7:0]:A[15:0] (autopush)
 .wrap
 
@@ -41,6 +41,7 @@ iswrite:                 ;Writes needs data to be stable (phi2 high)
 .program mia_read_addr
 .side_set 1 opt
 isrom:
+    nop                  [0] ;<- read addr timing adjust 0-7
     in pins 14               ;input address (auto-push)   
 .wrap_target
     wait 1 gpio 25           ;wait for phi2 raising edge
@@ -62,6 +63,7 @@ start:
     irq wait 5               ;wait on CPU signaling 
     mov osr !null            ;prepare indirs
     wait 1 gpio 25       [7] ;wait for phi2 raising edge
+    nop                  [0] ;<-io read timing adjust 0-7
     out pindirs 8 side 0     ;enable data output
 .wrap
 
@@ -74,13 +76,8 @@ start:
 .wrap_target
 start:
     wait 0 gpio 25      [7]  ;wait for phi2 falling edge
-    jmp pin start       [7]  ;RnW inverted. Pass on Read
-;    mov osr pins             ;collect pins
-;    out y 8                  ;select page
-;    jmp x!=y notio           ;pass if y = 0x03
-;    irq set 4                ;signal io_read program (0x03xx hit)
-notio:
     wait 1 gpio 25      [0]  ;wait for phi2 raising edge
+    jmp pin start            ;RnW inverted. Pass on Read
     mov osr pins
     out null 6
     out y 2
@@ -88,7 +85,7 @@ notio:
     out null 9               ;spool out RnW,D[7:0]
     out y 3                  ;collect MAP,DIR,Phi2
     jmp x!=y start           ;if not MAP,DIR,Phi2 right then jump to start
-    mov osr !null       [7]  ;prepare pindirs = 0xff
+    mov osr !null       [6]  ;prepare pindirs = 0xff
     out pindirs 8 side 0     ;enable data output and DIR B->A. disabled in mia_io_read
 .wrap
 
@@ -103,7 +100,7 @@ start:
     mov osr pins             ;ca 70 cycles delay before setting MAP
     out y 3                  ;get A[15:13]
     jmp x!=y start     [20]  ;check matching address
-    nop                [15]
+    nop                [15]  ;<- MAP/RV1 timing adjust 0-31
 ismap:
     set pins 1         [30]  ;Delay equals MAP pulse width
     set pins 0  

--- a/src/mia/sys/mia.pio
+++ b/src/mia/sys/mia.pio
@@ -13,16 +13,18 @@
 start:
     wait 1 gpio 25  [15]
 .wrap_target
-    wait 0 gpio 25  [29] ;wait for phi2 negative edge + setup <- act read timing adjust 0-31
+    wait 0 gpio 25  [29] ;wait for phi2 negative edge + setup
+    nop             [0]  ;<- act read timing adjust 0-31
     mov osr pins
     out null 8           ;Spool out A[7:0]
     out x 8              ;Get page address A[15:8]
     jmp x!=y start
     jmp pin iswrite      ;Handle writes later
-    in pins 25           ;Get RnW,D[7:0]:A[15:0] (autopush)
+    in pins 25           ;Get RnW,D[7:0]:A[15:0] (autopush) read - data ignored in action loop
     jmp start            ;
 iswrite:                 ;Writes needs data to be stable (phi2 high)
-    wait 1 gpio 25  [20] ;Delay needed for stable data sampling <- act write timing adjust 0-31
+    wait 1 gpio 25  [20] ;Delay needed for stable data sampling 
+    nop             [0]  ;<- act write timing adjust 0-31
     in pins 25           ;Get RnW,D[7:0]:A[15:0] (autopush)
 .wrap
 

--- a/src/mia/sys/mia.pio
+++ b/src/mia/sys/mia.pio
@@ -102,7 +102,7 @@ start:
     mov osr pins             ;ca 70 cycles delay before setting MAP
     out y 3                  ;get A[15:13]
     jmp x!=y start     [20]  ;check matching address
-    nop                [15]  ;<- MAP/RV1 timing adjust 0-31
+    nop                [10]  ;<- MAP/RV1 timing adjust 0-31
 ismap:
     set pins 1         [30]  ;Delay equals MAP pulse width
     set pins 0  

--- a/src/mia/tusb_config.h
+++ b/src/mia/tusb_config.h
@@ -42,7 +42,7 @@ extern "C"
 
 #define CFG_TUH_CDC_RX_BUFSIZE 64
 //Needs to be big enough to hold all stdio output before next call to tuh_task() 
-#define CFG_TUH_CDC_TX_BUFSIZE 2048
+#define CFG_TUH_CDC_TX_BUFSIZE 1200
 
 #define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM (0x03)
 //#define CFG_TUH_CDC_LINE_CODING_ON_ENUM { 115200, CDC_LINE_CODING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }


### PR DESCRIPTION
Added support for adjusting PIO timing related to interfacing with Oric. Accessible via the monitor <set> command and stored in CONFIG.SYS on internal flash. Unit for the timing is number of LOCI cycles, typically 8.33ns. These adjustmetns are additional delay on top of basic delay is already present in the PIO programs. 
```
set tmap <0-31>  ; cycles before asserting MAP signal. Default 10.
set tior <0-31>  ; cycles before IO address and R/W is sampled after PHI2 goes low. Default 0.
set tiow <0-31>  ; cycles before IO write data is sampled after PHI2 goes high. Default 0.
set tiod <0-7>   ; cycles before IO read data is driven on the bus after PHI2 goes high. Default 0.
set tadr <0-7>   ; cycles before ROM address and R/W is sampled after PHI2 goes low. Default 0.
```
MAP tuning is also exposed on the API to allow Oric ROMs to adjust it.