### PR TITLE
Add tior scanning function to API

### DIFF
--- a/src/mia/main.c
+++ b/src/mia/main.c
@@ -104,6 +104,7 @@ void main_task(void)
     std_task();
     led_task();
     pwr_task();
+    adj_task();
 }
 
 // Tasks that call FatFs should be here instead of main_task().
@@ -275,6 +276,8 @@ bool main_api(uint8_t operation)
     case 0xA5:
         map_api_tune_tadr();
         break;
+    case 0xA6:
+        adj_scan();
     default:
         return false;
     }

--- a/src/mia/sys/adj.c
+++ b/src/mia/sys/adj.c
@@ -2,6 +2,7 @@
 #include "str.h"
 #include <stdio.h>
 #include "sys/cfg.h"
+#include "sys/mem.h"
 #include "sys/mia.h"
 #include "pico/stdlib.h"
 #include "mia.pio.h"
@@ -66,4 +67,55 @@ void adj_init(void){
     adj_io_read_delay(cfg_get_io_read_delay());
     adj_io_data_delay(cfg_get_io_data_delay());
     adj_read_addr_delay(cfg_get_read_addr_delay());
+}
+
+static enum {
+    ADJ_IDLE,
+    ADJ_SCAN,
+    ADJ_CLEANUP,
+} adj_state;
+
+bool adj_active(void){
+    return adj_state != ADJ_IDLE;
+}
+static bool adj_scan_requested = false;
+
+void adj_scan(void){
+    adj_scan_requested = true;
+}
+#define ADJ_SCAN_TIME_US 100
+void adj_task(void){
+    static uint8_t tior; 
+    static absolute_time_t adj_timer;
+    switch(adj_state){
+        case(ADJ_IDLE):
+            if(adj_scan_requested){
+                adj_scan_requested = false;
+                adj_state = ADJ_SCAN;
+                adj_timer = delayed_by_us(get_absolute_time(), ADJ_SCAN_TIME_US);
+                tior = 0;
+                adj_io_read_delay(tior);
+                xram[0xFFF0] = 0x80 | tior;     //Flag scanning by setting MSB
+            }
+            break;
+        case(ADJ_SCAN):
+            if(absolute_time_diff_us(get_absolute_time(), adj_timer) < 0){
+                if(tior++ > 31){
+                    adj_state = ADJ_CLEANUP;
+                }else{
+                    adj_timer = delayed_by_us(get_absolute_time(), ADJ_SCAN_TIME_US);
+                    adj_io_read_delay(tior);
+                    xram[0xFFF0] = 0x80 | tior;
+                }
+            }
+            break;
+        case(ADJ_CLEANUP):
+            tior = cfg_get_io_read_delay();
+            adj_io_read_delay(tior);
+            xram[0xFFF0] = tior;
+            adj_state = ADJ_IDLE;
+            break;
+        default:
+            break;
+    }
 }

--- a/src/mia/sys/adj.h
+++ b/src/mia/sys/adj.h
@@ -8,3 +8,5 @@ uint8_t adj_io_data_delay(uint8_t delay);
 uint8_t adj_read_addr_delay(uint8_t delay);
 
 void adj_init(void);
+void adj_scan(void);
+void adj_task(void);


### PR DESCRIPTION
Add tior timing scan API function. Allows ROM to do a low-risk test of the Oric-LOCI tior timing parameter across its range. 