### PR TITLE
fix(msc): don't truncate USB sector count to 16 bits

### DIFF
--- a/src/mia/usb/msc.c
+++ b/src/mia/usb/msc.c
@@ -160,7 +160,7 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
     case CTRL_SYNC:
         return RES_OK;
     case GET_SECTOR_COUNT:
-        *((DWORD *)buff) = (WORD)tuh_msc_get_block_count(dev_addr, lun);
+        *((DWORD *)buff) = tuh_msc_get_block_count(dev_addr, lun);
         return RES_OK;
     case GET_SECTOR_SIZE:
         *((WORD *)buff) = (WORD)tuh_msc_get_block_size(dev_addr, lun);


### PR DESCRIPTION
`disk_ioctl(GET_SECTOR_COUNT)` casts the return of `tuh_msc_get_block_count()` (`uint32_t`) to `(WORD)` before storing it in the `DWORD` FatFs expects (`src/mia/usb/msc.c:163`). Above 65 535 sectors (~32 MB at 512 B/sector) the count is truncated, so FatFs can mis-size large USB drives.

**Fix:** drop the `(WORD)` cast — assign the full `uint32_t` to the `DWORD` (both 32-bit). One line.

Verified `git apply --check` on `main` (v0.3.1) and **compiles clean** with the RP2040 toolchain (arm-none-eabi-gcc 14.2.1, MinSizeRel). Runtime not verified on my side (no >32 GB key at hand) — flagged as such.
