### PR TITLE
fix(dsk): STEP_OUT must decrement the track and set 'out' direction

### DIFF
--- a/src/mia/oric/dsk.c
+++ b/src/mia/oric/dsk.c
@@ -809,9 +809,9 @@ uint8_t dsk_cmd(uint8_t raw_cmd){
                 break;
             case STEP_OUT:
                 if(dsk_active.track > 0){
-                    dsk_next_track = dsk_active.track + 1;
+                    dsk_next_track = dsk_active.track - 1;
                 }
-                dsk_active.step_dir_out = false;
+                dsk_active.step_dir_out = true;
                 break;
             default:
                 //fail


### PR DESCRIPTION
The WD179x STEP OUT command moves the head towards track 0. The current code incremented the track (`track+1`) and set `step_dir_out=false` (the 'in' direction), i.e. it behaved identically to STEP_IN.

Consequences:
- relative seeks (STEP, STEP_OUT) move the wrong way;
- the bare STEP command inherits an inverted direction.

Fix: `track-1` and `step_dir_out=true`, per the WD1793 datasheet and by symmetry with STEP_IN (`track+1` / `false`).

Single-line-scope change in `src/mia/oric/dsk.c`, no functional impact outside the WD179x STEP OUT path.